### PR TITLE
Add orange randomizer intensity swatch (level 5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,8 @@
       <div class="swatch" data-level="2" style="background:#016C31" title="Level 2"></div>
       <div class="swatch" data-level="3" style="background:#26A641" title="Level 3"></div>
       <div class="swatch" data-level="4" style="background:#39D353" title="Level 4"></div>
-      <span class="legend-key" data-i18n="legend_hint">keys 0–4 &nbsp;|&nbsp; click and drag</span>
+      <div class="swatch" data-level="5" style="background:#f39c12" title="Random 1-4"></div>
+      <span class="legend-key" data-i18n="legend_hint">keys 0–5 &nbsp;|&nbsp; click and drag</span>
     </div>
     <div class="graph-wrap">
       <div class="day-labels">

--- a/js/app.js
+++ b/js/app.js
@@ -35,7 +35,7 @@ document.getElementById('langSelect').addEventListener('change', e=>{
 
 // ── Graph state ──
 const ROWS = 7;
-const COLORS = ['#21262d','#0D4429','#016C31','#26A641','#39D353'];
+const COLORS = ['#21262d','#0D4429','#016C31','#26A641','#39D353','#f39c12'];
 let grid = [], selLevel = 0, isDown = false;
 let startDate = new Date();
 let totalCols = 53;
@@ -120,11 +120,17 @@ function rebuildGraph(){
   updateStats();
 }
 
+function resolveLevel(){
+  if(selLevel === 5) return Math.floor(Math.random() * 4) + 1;
+  return selLevel;
+}
+
 function paint(cell){
   if(cell.classList.contains('out')) return;
   const i = +cell.dataset.i;
-  grid[i] = selLevel;
-  cell.style.background = COLORS[selLevel];
+  const level = resolveLevel();
+  grid[i] = level;
+  cell.style.background = COLORS[level];
   updateStats();
 }
 
@@ -145,7 +151,7 @@ document.querySelectorAll('.swatch').forEach(s => s.addEventListener('click', ()
 document.addEventListener('keydown', e=>{
   if(['INPUT','TEXTAREA','SELECT'].includes(document.activeElement.tagName)) return;
   const n = parseInt(e.key);
-  if(n >= 0 && n <= 4){
+  if(n >= 0 && n <= 5){
     selLevel = n;
     document.querySelectorAll('.swatch').forEach(s => s.classList.toggle('sel', +s.dataset.level === n));
   }
@@ -160,13 +166,18 @@ document.getElementById('clearBtn').addEventListener('click', ()=>{
 });
 document.getElementById('fillBtn').addEventListener('click', ()=>{
   document.querySelectorAll('.cell:not(.out)').forEach(c=>{
-    const i = +c.dataset.i; grid[i] = selLevel; c.style.background = COLORS[selLevel];
+    const i = +c.dataset.i;
+    const level = resolveLevel();
+    grid[i] = level;
+    c.style.background = COLORS[level];
   });
   updateStats();
 });
 document.getElementById('invertBtn').addEventListener('click', ()=>{
   document.querySelectorAll('.cell:not(.out)').forEach(c=>{
-    const i = +c.dataset.i; grid[i] = grid[i] === 0 ? selLevel : 0; c.style.background = COLORS[grid[i]];
+    const i = +c.dataset.i;
+    grid[i] = grid[i] === 0 ? resolveLevel() : 0;
+    c.style.background = COLORS[grid[i]];
   });
   updateStats();
 });

--- a/js/i18n/cs-CZ.js
+++ b/js/i18n/cs-CZ.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('cs-CZ', {
   year_hint: 'Graf pokrývá celý vybraný rok',
   editor_title: 'Editor',
   intensity: 'Intenzita:',
-  legend_hint: 'klávesy 0–4 | klikni a táhni',
+  legend_hint: 'klávesy 0–5 | klikni a táhni',
   btn_clear: 'Vyčistit',
   btn_fill: 'Vyplnit vše',
   btn_invert: 'Invertovat',

--- a/js/i18n/de-DE.js
+++ b/js/i18n/de-DE.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('de-DE', {
   year_hint: 'Der Graph deckt das gesamte ausgewählte Jahr ab',
   editor_title: 'Editor',
   intensity: 'Intensität:',
-  legend_hint: 'Tasten 0–4 | klicken und ziehen',
+  legend_hint: 'Tasten 0–5 | klicken und ziehen',
   btn_clear: 'Leeren',
   btn_fill: 'Alles füllen',
   btn_invert: 'Invertieren',

--- a/js/i18n/en-US.js
+++ b/js/i18n/en-US.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('en-US', {
   year_hint: 'The graph covers the entire selected year',
   editor_title: 'Editor',
   intensity: 'Intensity:',
-  legend_hint: 'keys 0–4 | click and drag',
+  legend_hint: 'keys 0–5 | click and drag',
   btn_clear: 'Clear',
   btn_fill: 'Fill all',
   btn_invert: 'Invert',

--- a/js/i18n/fr-FR.js
+++ b/js/i18n/fr-FR.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('fr-FR', {
   year_hint: 'Le graphe couvre toute l’année sélectionnée',
   editor_title: 'Éditeur',
   intensity: 'Intensité :',
-  legend_hint: 'touches 0–4 | cliquer et glisser',
+  legend_hint: 'touches 0–5 | cliquer et glisser',
   btn_clear: 'Effacer',
   btn_fill: 'Tout remplir',
   btn_invert: 'Inverser',

--- a/js/i18n/ja-JP.js
+++ b/js/i18n/ja-JP.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('ja-JP', {
   year_hint: 'グラフは選択した年全体を表示します',
   editor_title: 'エディタ',
   intensity: '強度:',
-  legend_hint: 'キー 0–4 | クリックしてドラッグ',
+  legend_hint: 'キー 0–5 | クリックしてドラッグ',
   btn_clear: 'クリア',
   btn_fill: 'すべて塗る',
   btn_invert: '反転',

--- a/js/i18n/kk-KZ.js
+++ b/js/i18n/kk-KZ.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('kk-KZ', {
   year_hint: 'График таңдалған жылды толық қамтиды',
   editor_title: 'Редактор',
   intensity: 'Қарқындылық:',
-  legend_hint: '0–4 пернелері | басып сүйреңіз',
+  legend_hint: '0–5 пернелері | басып сүйреңіз',
   btn_clear: 'Тазалау',
   btn_fill: 'Барлығын толтыру',
   btn_invert: 'Кері аудару',

--- a/js/i18n/nl-NL.js
+++ b/js/i18n/nl-NL.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('nl-NL', {
   year_hint: 'De grafiek toont het volledige geselecteerde jaar',
   editor_title: 'Editor',
   intensity: 'Intensiteit:',
-  legend_hint: 'toetsen 0–4 | klik en sleep',
+  legend_hint: 'toetsen 0–5 | klik en sleep',
   btn_clear: 'Wissen',
   btn_fill: 'Alles vullen',
   btn_invert: 'Omkeren',

--- a/js/i18n/pl-PL.js
+++ b/js/i18n/pl-PL.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('pl-PL', {
   year_hint: 'Wykres obejmuje cały wybrany rok',
   editor_title: 'Edytor',
   intensity: 'Intensywność:',
-  legend_hint: 'klawisze 0–4 | kliknij i przeciągnij',
+  legend_hint: 'klawisze 0–5 | kliknij i przeciągnij',
   btn_clear: 'Wyczyść',
   btn_fill: 'Wypełnij wszystko',
   btn_invert: 'Odwróć',

--- a/js/i18n/ru-RU.js
+++ b/js/i18n/ru-RU.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('ru-RU', {
   year_hint: 'График охватывает весь выбранный год',
   editor_title: 'Редактор',
   intensity: 'Интенсивность:',
-  legend_hint: 'клавиши 0–4 | зажмите и ведите',
+  legend_hint: 'клавиши 0–5 | зажмите и ведите',
   btn_clear: 'Очистить',
   btn_fill: 'Залить всё',
   btn_invert: 'Инвертировать',

--- a/js/i18n/sv-SE.js
+++ b/js/i18n/sv-SE.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('sv-SE', {
   year_hint: 'Grafen täcker hela det valda året',
   editor_title: 'Redigerare',
   intensity: 'Intensitet:',
-  legend_hint: 'tangenter 0–4 | klicka och dra',
+  legend_hint: 'tangenter 0–5 | klicka och dra',
   btn_clear: 'Rensa',
   btn_fill: 'Fyll allt',
   btn_invert: 'Invertera',

--- a/js/i18n/uk-UA.js
+++ b/js/i18n/uk-UA.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('uk-UA', {
   year_hint: 'Графік охоплює весь вибраний рік',
   editor_title: 'Редактор',
   intensity: 'Інтенсивність:',
-  legend_hint: 'клавіші 0–4 | затисніть і ведіть',
+  legend_hint: 'клавіші 0–5 | затисніть і ведіть',
   btn_clear: 'Очистити',
   btn_fill: 'Заповнити все',
   btn_invert: 'Інвертувати',

--- a/js/i18n/zh-CN.js
+++ b/js/i18n/zh-CN.js
@@ -14,7 +14,7 @@ window.I18N.registerLocale('zh-CN', {
   year_hint: '图表覆盖所选年份的全部日期',
   editor_title: '编辑器',
   intensity: '强度：',
-  legend_hint: '按键 0–4 | 点击并拖动',
+  legend_hint: '按键 0–5 | 点击并拖动',
   btn_clear: '清空',
   btn_fill: '全部填充',
   btn_invert: '反转',


### PR DESCRIPTION
### Motivation

- Provide a quick way to paint with randomized intensities so each painted cell can get a random level between `1` and `4` without manual selection.

### Description

- Added a fifth swatch in `index.html` (`data-level="5"`) with orange color and title `Random 1-4` next to the existing intensity swatches.
- Extended `COLORS` in `js/app.js` to include the orange color and added `resolveLevel()` which returns a random integer `1..4` when `selLevel === 5`.
- Updated `paint()` and the handlers for `Fill all` and `Invert` so they use `resolveLevel()` when assigning cells, and expanded keyboard support to accept keys `0`–`5`.
- Updated all locale hint strings (`js/i18n/*.js`) from `0–4` to `0–5` to reflect the new shortcut.

### Testing

- Ran `node --check js/app.js` and it completed successfully.
- Ran `for f in js/i18n/*.js; do node --check "$f"; done` and all locale files passed the syntax check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42da29bdc833195ac5a16e7ec6e67)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new painting level (Level 5: Random 1-4) that randomly generates a level between 1 and 4
  * Extended keyboard shortcuts to support keys 0–5 for level selection

* **Localization**
  * Updated all language translations to reflect the expanded key range (0–5)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->