### PR TITLE
Replace invert action with multiplier-based random fill

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
     <div class="btn-row">
       <button class="danger" id="clearBtn" data-i18n="btn_clear">Clear</button>
       <button id="fillBtn" data-i18n="btn_fill">Fill all</button>
-      <button id="invertBtn" data-i18n="btn_invert">Invert</button>
+      <button id="invertBtn" data-i18n="btn_invert">Random</button>
       <button class="primary" id="pushBtn" data-i18n="btn_push">▶ Apply to GitHub</button>
     </div>
     <div class="progress" id="progress">

--- a/js/app.js
+++ b/js/app.js
@@ -173,10 +173,16 @@ document.getElementById('fillBtn').addEventListener('click', ()=>{
   });
   updateStats();
 });
+function randomLevelByMultiplier(){
+  const mult = +document.getElementById('multiplier').value;
+  const maxLevel = Math.min(4, Math.max(1, Math.ceil(mult / 2.5)));
+  return Math.floor(Math.random() * (maxLevel + 1));
+}
+
 document.getElementById('invertBtn').addEventListener('click', ()=>{
   document.querySelectorAll('.cell:not(.out)').forEach(c=>{
     const i = +c.dataset.i;
-    grid[i] = grid[i] === 0 ? resolveLevel() : 0;
+    grid[i] = randomLevelByMultiplier();
     c.style.background = COLORS[grid[i]];
   });
   updateStats();

--- a/js/i18n/cs-CZ.js
+++ b/js/i18n/cs-CZ.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('cs-CZ', {
   legend_hint: 'klávesy 0–5 | klikni a táhni',
   btn_clear: 'Vyčistit',
   btn_fill: 'Vyplnit vše',
-  btn_invert: 'Invertovat',
+  btn_invert: 'Náhodně',
   btn_push: '▶ Použít na GitHub',
   days_painted: 'Obarvené dny:',
   commits: 'Commity:',

--- a/js/i18n/de-DE.js
+++ b/js/i18n/de-DE.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('de-DE', {
   legend_hint: 'Tasten 0–5 | klicken und ziehen',
   btn_clear: 'Leeren',
   btn_fill: 'Alles füllen',
-  btn_invert: 'Invertieren',
+  btn_invert: 'Zufällig',
   btn_push: '▶ Auf GitHub anwenden',
   days_painted: 'Bemalte Tage:',
   commits: 'Commits:',

--- a/js/i18n/en-US.js
+++ b/js/i18n/en-US.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('en-US', {
   legend_hint: 'keys 0–5 | click and drag',
   btn_clear: 'Clear',
   btn_fill: 'Fill all',
-  btn_invert: 'Invert',
+  btn_invert: 'Random',
   btn_push: '▶ Apply to GitHub',
   days_painted: 'Days painted:',
   commits: 'Commits:',

--- a/js/i18n/fr-FR.js
+++ b/js/i18n/fr-FR.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('fr-FR', {
   legend_hint: 'touches 0–5 | cliquer et glisser',
   btn_clear: 'Effacer',
   btn_fill: 'Tout remplir',
-  btn_invert: 'Inverser',
+  btn_invert: 'Aléatoire',
   btn_push: '▶ Appliquer sur GitHub',
   days_painted: 'Jours peints :',
   commits: 'Commits :',

--- a/js/i18n/ja-JP.js
+++ b/js/i18n/ja-JP.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('ja-JP', {
   legend_hint: 'キー 0–5 | クリックしてドラッグ',
   btn_clear: 'クリア',
   btn_fill: 'すべて塗る',
-  btn_invert: '反転',
+  btn_invert: 'ランダム',
   btn_push: '▶ GitHub に適用',
   days_painted: '塗った日数:',
   commits: 'コミット数:',

--- a/js/i18n/kk-KZ.js
+++ b/js/i18n/kk-KZ.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('kk-KZ', {
   legend_hint: '0–5 пернелері | басып сүйреңіз',
   btn_clear: 'Тазалау',
   btn_fill: 'Барлығын толтыру',
-  btn_invert: 'Кері аудару',
+  btn_invert: 'Кездейсоқ',
   btn_push: '▶ GitHub-қа қолдану',
   days_painted: 'Боялған күндер:',
   commits: 'Commit саны:',

--- a/js/i18n/nl-NL.js
+++ b/js/i18n/nl-NL.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('nl-NL', {
   legend_hint: 'toetsen 0–5 | klik en sleep',
   btn_clear: 'Wissen',
   btn_fill: 'Alles vullen',
-  btn_invert: 'Omkeren',
+  btn_invert: 'Willekeurig',
   btn_push: '▶ Toepassen op GitHub',
   days_painted: 'Ingekleurde dagen:',
   commits: 'Commits:',

--- a/js/i18n/pl-PL.js
+++ b/js/i18n/pl-PL.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('pl-PL', {
   legend_hint: 'klawisze 0–5 | kliknij i przeciągnij',
   btn_clear: 'Wyczyść',
   btn_fill: 'Wypełnij wszystko',
-  btn_invert: 'Odwróć',
+  btn_invert: 'Losowo',
   btn_push: '▶ Zastosuj na GitHub',
   days_painted: 'Pomalowane dni:',
   commits: 'Commity:',

--- a/js/i18n/ru-RU.js
+++ b/js/i18n/ru-RU.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('ru-RU', {
   legend_hint: 'клавиши 0–5 | зажмите и ведите',
   btn_clear: 'Очистить',
   btn_fill: 'Залить всё',
-  btn_invert: 'Инвертировать',
+  btn_invert: 'Рандомно',
   btn_push: '▶ Применить на GitHub',
   days_painted: 'Закрашено дней:',
   commits: 'Коммитов:',

--- a/js/i18n/sv-SE.js
+++ b/js/i18n/sv-SE.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('sv-SE', {
   legend_hint: 'tangenter 0–5 | klicka och dra',
   btn_clear: 'Rensa',
   btn_fill: 'Fyll allt',
-  btn_invert: 'Invertera',
+  btn_invert: 'Slumpmässigt',
   btn_push: '▶ Använd på GitHub',
   days_painted: 'Färgade dagar:',
   commits: 'Commits:',

--- a/js/i18n/uk-UA.js
+++ b/js/i18n/uk-UA.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('uk-UA', {
   legend_hint: 'клавіші 0–5 | затисніть і ведіть',
   btn_clear: 'Очистити',
   btn_fill: 'Заповнити все',
-  btn_invert: 'Інвертувати',
+  btn_invert: 'Випадково',
   btn_push: '▶ Застосувати в GitHub',
   days_painted: 'Зафарбовано днів:',
   commits: 'Комітів:',

--- a/js/i18n/zh-CN.js
+++ b/js/i18n/zh-CN.js
@@ -17,7 +17,7 @@ window.I18N.registerLocale('zh-CN', {
   legend_hint: '按键 0–5 | 点击并拖动',
   btn_clear: '清空',
   btn_fill: '全部填充',
-  btn_invert: '反转',
+  btn_invert: '随机',
   btn_push: '▶ 应用到 GitHub',
   days_painted: '已绘制天数：',
   commits: '提交数：',


### PR DESCRIPTION
### Motivation
- The invert action should behave as a random fill that respects the commit `multiplier`, so cells receive random intensity values instead of toggling on/off.
- Make the UI label and translations reflect the new behavior so users understand the button now produces randomized intensities.

### Description
- Replaced the `#invertBtn` handler to fill all active cells with a random intensity computed by `randomLevelByMultiplier()` instead of toggling invert behavior (`js/app.js` lines ~176-189). 
- Added `randomLevelByMultiplier()` in `js/app.js` which maps the current multiplier to a `maxLevel` (capped at 4) and returns a uniform random integer in `0..maxLevel` so intensity distribution depends on `multiplier`.
- Updated the button label in `index.html` from `Invert` to `Random` and updated the `btn_invert` translation string across i18n files so the UI text matches the new action (`index.html`, `js/i18n/*.js`).

### Testing
- Ran `node --check js/app.js` which completed successfully.
- Served the site with `python -m http.server 4173` and verified the app loads in a browser session successfully.
- Automated a browser check with Playwright that selects `ru-RU`, clicks `#invertBtn`, and captured a screenshot showing randomized coloring, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4345eb4d88331a65102933b3087f9)