### PR TITLE
Remove Random button and random-fill handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,6 @@
     <div class="btn-row">
       <button class="danger" id="clearBtn" data-i18n="btn_clear">Clear</button>
       <button id="fillBtn" data-i18n="btn_fill">Fill all</button>
-      <button id="invertBtn" data-i18n="btn_invert">Random</button>
       <button class="primary" id="pushBtn" data-i18n="btn_push">▶ Apply to GitHub</button>
     </div>
     <div class="progress" id="progress">

--- a/js/app.js
+++ b/js/app.js
@@ -173,21 +173,6 @@ document.getElementById('fillBtn').addEventListener('click', ()=>{
   });
   updateStats();
 });
-function randomLevelByMultiplier(){
-  const mult = +document.getElementById('multiplier').value;
-  const maxLevel = Math.min(4, Math.max(1, Math.ceil(mult / 2.5)));
-  return Math.floor(Math.random() * (maxLevel + 1));
-}
-
-document.getElementById('invertBtn').addEventListener('click', ()=>{
-  document.querySelectorAll('.cell:not(.out)').forEach(c=>{
-    const i = +c.dataset.i;
-    grid[i] = randomLevelByMultiplier();
-    c.style.background = COLORS[grid[i]];
-  });
-  updateStats();
-});
-
 // ── Logging ──
 function addLog(msg, type){
   const log = document.getElementById('log');


### PR DESCRIPTION
### Motivation
- The UI should no longer offer the `Random` action and the associated random-fill behavior is not needed.
- Simplify the editor controls by removing an extra button and its unused JS logic.

### Description
- Removed the `Random` button from the editor action row in `index.html` so the row now contains `Clear`, `Fill all`, and `Apply to GitHub` only.
- Deleted the `randomLevelByMultiplier` helper and the `invertBtn` click handler from `js/app.js`, eliminating the random grid-fill code path.

### Testing
- Ran syntax check with `node --check js/app.js` and it completed successfully.
- Verified no remaining references with `rg -n "invertBtn|randomLevelByMultiplier" index.html js/app.js` which returned no matches.
- Launched a local server with `python -m http.server 4173` and visually validated the UI; a Playwright screenshot was captured to confirm the button is removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b460a098f083319f2ef3f347f29bc3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features Removed**
  * Removed the Random button from the editor controls, eliminating the ability to populate grid cells with random values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->