### PR TITLE
Add configurable Fill % control for randomized Fill action

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -75,7 +75,9 @@
   .stat b { color: var(--text); font-weight: 600; }
 
   /* BUTTONS */
-  .btn-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+  .btn-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; align-items: center; }
+  .fill-percent-control { display: inline-flex; align-items: center; gap: 6px; color: var(--text2); font-size: 12px; }
+  .fill-percent-control input { width: 70px; height: 34px; }
   button { height: 34px; padding: 0 16px; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; border: 1px solid var(--border); background: var(--bg3); color: var(--text); transition: background .15s, opacity .15s; white-space: nowrap; }
   button:hover { background: #30363d; }
   button:disabled { opacity: .4; cursor: not-allowed; }

--- a/index.html
+++ b/index.html
@@ -129,6 +129,10 @@
     <div class="btn-row">
       <button class="danger" id="clearBtn" data-i18n="btn_clear">Clear</button>
       <button id="fillBtn" data-i18n="btn_fill">Fill all</button>
+      <label class="fill-percent-control" for="fillPercent">
+        <span>Fill %</span>
+        <input id="fillPercent" type="text" value="100%" inputmode="decimal" aria-label="Fill percentage" />
+      </label>
       <button class="primary" id="pushBtn" data-i18n="btn_push">▶ Apply to GitHub</button>
     </div>
     <div class="progress" id="progress">

--- a/js/app.js
+++ b/js/app.js
@@ -134,6 +134,24 @@ function paint(cell){
   updateStats();
 }
 
+
+function getFillPercent(){
+  const input = document.getElementById('fillPercent');
+  const parsed = Number.parseFloat(input.value.replace(',', '.'));
+  const safe = Number.isFinite(parsed) ? Math.min(100, Math.max(0, parsed)) : 100;
+  input.value = `${safe}%`;
+  return safe;
+}
+
+function pickRandomCells(cells, count){
+  const pool = [...cells];
+  for(let i = pool.length - 1; i > 0; i--){
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return pool.slice(0, count);
+}
+
 function updateStats(){
   const mult = +document.getElementById('multiplier').value;
   const isSpreadEnabled = document.getElementById('commitSpread').value === 'plus2';
@@ -171,11 +189,21 @@ document.getElementById('clearBtn').addEventListener('click', ()=>{
   updateStats(); setStatus('');
 });
 document.getElementById('fillBtn').addEventListener('click', ()=>{
-  document.querySelectorAll('.cell:not(.out)').forEach(c=>{
+  const fillPercent = getFillPercent();
+  const activeCells = [...document.querySelectorAll('.cell:not(.out)')];
+  const targetCount = Math.round(activeCells.length * (fillPercent / 100));
+  const picked = new Set(pickRandomCells(activeCells, targetCount));
+
+  activeCells.forEach(c=>{
     const i = +c.dataset.i;
-    const level = resolveLevel();
-    grid[i] = level;
-    c.style.background = COLORS[level];
+    if(picked.has(c)){
+      const level = resolveLevel();
+      grid[i] = level;
+      c.style.background = COLORS[level];
+      return;
+    }
+    grid[i] = 0;
+    c.style.background = COLORS[0];
   });
   updateStats();
 });


### PR DESCRIPTION
### Motivation
- Provide a way to fill only a portion of the active grid when using the existing `Fill all` action by allowing the user to enter a percentage (e.g. `48%`) that will randomly paint that share of cells.

### Description
- Added a `Fill %` input control in the UI (`index.html`) with a default value of `100%` to let users specify the desired fill ratio.
- Added lightweight styling for the control in `css/styles.css` so it aligns with the existing button row.
- Implemented `getFillPercent` and `pickRandomCells` helpers and updated the `Fill all` handler in `js/app.js` to parse/clamp the percentage, randomly select the target number of active cells, paint those cells with the chosen level, and reset non-selected cells to empty.
- Input parsing normalizes decimal separators, clamps the value to `0..100`, and writes back a normalized value (e.g. `48%`).

### Testing
- Ran `node --check js/app.js` to validate JS syntax, which succeeded.
- Executed an automated Playwright run that opened the local server and produced a screenshot of the updated UI at `artifacts/fill-percent-ui.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4699b2a0483318f0c3bb84de169d1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable fill percentage control allowing users to randomly fill a specified percentage (0-100%) of cells in the grid.

* **Style**
  * Improved alignment of buttons in the action row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->